### PR TITLE
Link against libc++ on OSX

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,14 @@
 #!/bin/env bash
 
+
+# FIXME: This is a hack to make sure the environment is activated.
+# The reason this is required is due to the conda-build issue
+# mentioned below.
+#
+# https://github.com/conda/conda-build/issues/910
+#
+source activate "${CONDA_DEFAULT_ENV}"
+
 ./autogen.sh
 ./configure --with-pic --prefix=$PREFIX
 make

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,11 +10,12 @@ source:
   md5: 7358c82f133dc77798e4c2062a749b73
 
 build:
-  number: 1
+  number: 2
   skip: true      # [win]
 
 requirements:
   build:
+    - toolchain
     - msinttypes  # [win]
     - libtool     # [unix]
     - automake    # [unix]


### PR DESCRIPTION
This avoids linking problems in dependents that use C++11.
