### PR TITLE
bump to 1.1.6

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -21,4 +21,5 @@ fi
 ./configure --with-pic --prefix=$PREFIX --disable-dependency-tracking
 make
 make check
+ln README.md README  # hack; snappy autotools build is broken in 1.1.6
 make install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -21,5 +21,4 @@ fi
 ./configure --with-pic --prefix=$PREFIX --disable-dependency-tracking
 make
 make check
-ln README.md README  # hack; snappy autotools build is broken in 1.1.6
 make install

--- a/recipe/fix-autoconf-readme.patch
+++ b/recipe/fix-autoconf-readme.patch
@@ -1,0 +1,22 @@
+From ca1709220830849530cca59839da665d924fcc41 Mon Sep 17 00:00:00 2001
+From: "Dougal J. Sutherland" <dougal@gmail.com>
+Date: Thu, 20 Jul 2017 20:50:15 +0100
+Subject: [PATCH] fix autoconf README.md workaround
+
+---
+ Makefile.am | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index 0746a16..640d544 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -28,4 +28,4 @@ libtool: $(LIBTOOL_DEPS)
+ # Needed by autoconf because we use README.md instead of README.
+ # See http://stackoverflow.com/q/15013672/
+ README: README.md
+-	cat $< > $@.tmp
++	cp $< $@
+-- 
+2.13.3
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,11 @@ source:
   url: https://github.com/google/snappy/archive/{{ version }}.tar.gz
   fn: snappy-{{ version }}.tar.gz
   sha256: 6fa92cde5b2caefd0d9a60336991ba42e5a7ddc3bdc36c5610451373751d0495
+  patches:
+    # 1.1.6 crashes because it tries to install README, but the file is now
+    # named README.md. This patch is submitted upstream:
+    # https://github.com/google/snappy/pull/46
+    - fix-autoconf-readme.patch
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,16 @@
-{% set version = "1.1.4" %}
+{% set version = "1.1.6" %}
 
 package:
   name: snappy
   version: {{ version }}
 
 source:
-  url: https://github.com/google/snappy/releases/download/{{ version }}/snappy-{{ version }}.tar.gz
+  url: https://github.com/google/snappy/archive/{{ version }}.tar.gz
   fn: snappy-{{ version }}.tar.gz
-  sha256: 134bfe122fd25599bb807bb8130e7ba6d9bdb851e0b16efcb83ac4f5d0b70057
+  sha256: 6fa92cde5b2caefd0d9a60336991ba42e5a7ddc3bdc36c5610451373751d0495
 
 build:
-  number: 1
+  number: 0
   skip: true      # [win]
 
 requirements:


### PR DESCRIPTION
Without making the cmake changes and stuff from #10; just bump version number. (Had to change the URL too since this release doesn't have an "official" tar.gz in the release, just the git tag version.)