### PR TITLE
don't look for zlib

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,6 +20,7 @@ function build() {
         -DCMAKE_INSTALL_PREFIX="$PREFIX" \
         -DCMAKE_PREFIX_PATH="$PREFIX" \
         -DCMAKE_INSTALL_LIBDIR=lib \
+        -DHAVE_LIBZ=FALSE -DHAVE_LIBLZO2=FALSE \
         $extra_args
 
     make -j $CPU_COUNT

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "1.1.7" %}
 {% set sha256 = "3dfa02e873ff51a11ee02b9ca391807f0c8ea0529a4924afa645fbf97163f9d4" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 package:
   name: snappy


### PR DESCRIPTION
Fixes #15. I'm confused about why it's failing, but libz is only used in the benchmarking test that we're not running anyway, so might as well tell cmake not to use it.