### PR TITLE
Add repository URL to package metadata

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: osx
   pool:
-    vmImage: macOS-13
+    vmImage: macOS-15
   strategy:
     matrix:
       osx_64_:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -6,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -6,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,8 +31,6 @@ pkgs_dirs:
 solver: libmamba
 
 CONDARC
-curl -fsSL https://pixi.sh/install.sh | bash
-export PATH="~/.pixi/bin:$PATH"
 pushd "${FEEDSTOCK_ROOT}"
 arch=$(uname -m)
 if [[ "$arch" == "x86_64" ]]; then

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Package license: BSD-3-Clause
 
 Summary: A fast compressor/decompressor
 
+Development: https://github.com/google/snappy
+
 Current build status
 ====================
 
@@ -152,12 +154,12 @@ it is possible to build and upload installable packages to the
 [conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
-To manage the continuous integration and simplify feedstock maintenance
+To manage the continuous integration and simplify feedstock maintenance,
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
-For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
+For more information, please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========
@@ -184,7 +186,7 @@ merged, the recipe will be re-built and uploaded automatically to the
 everybody to install and use from the `conda-forge` channel.
 Note that all branches in the conda-forge/snappy-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
-on branches in forks and branches in the main repository should only be used to
+on branches in forks, and branches in the main repository should only be used to
 build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,24 +1,22 @@
+# -*- mode: toml -*-
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yml and/or the recipe/meta.yaml.
-# -*- mode: toml -*-
+"$schema" = "https://pixi.sh/v0.59.0/schema/manifest/schema.json"
 
-#                             VVVVVV  minimum `pixi` version
-"$schema" = "https://pixi.sh/v0.36.0/schema/manifest/schema.json"
-
-[project]
+[workspace]
 name = "snappy-feedstock"
-version = "3.51.1"  # conda-smithy version used to generate this file
+version = "3.53.0"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/snappy-feedstock"
 authors = ["@conda-forge/snappy"]
 channels = ["conda-forge"]
 platforms = ["linux-64", "osx-64", "win-64"]
+requires-pixi = ">=0.59.0"
 
 [dependencies]
 conda-build = ">=24.1"
 conda-forge-ci-setup = "4.*"
 rattler-build = "*"
 
-[tasks]
 [tasks.inspect-all]
 cmd = "inspect_artifacts --all-packages"
 description = "List contents of all packages found in rattler-build build directory."
@@ -79,5 +77,6 @@ description = "Lint the feedstock recipe"
 
 [environments]
 smithy = ["smithy"]
+
 # This is a copy of default, to be enabled by build_steps.sh during Docker builds
 # __PLATFORM_SPECIFIC_ENV__ = []

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -21,7 +21,7 @@ source:
     - patches/0005-Omit-Werror-during-compilation.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -68,6 +68,7 @@ about:
   license: BSD-3-Clause
   license_file: COPYING
   homepage: https://github.com/google/snappy
+  repository: https://github.com/google/snappy
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
We would like to have automated checks on build packages and for those the correct repository URL would be helpful. As these checks run on build packages I also increased the build number.

cc @xhochy